### PR TITLE
Patch missing modules from manifest which makes netbox-docker fail to initialise

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ recursive-include netbox_secretstore/forms *
 recursive-include netbox_secretstore/project-static *
 recursive-include netbox_secretstore/migrations *
 recursive-include netbox_secretstore/api *
+recursive-include netbox_secretstore/utils *
 
 
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,12 @@ include README.md
 include LICENSE
 recursive-include netbox_secretstore/templates *
 recursive-include netbox_secretstore/static *
+recursive-include netbox_secretstore/models *
+recursive-include netbox_secretstore/forms *
+recursive-include netbox_secretstore/project-static *
+recursive-include netbox_secretstore/migrations *
+recursive-include netbox_secretstore/api *
+
+
+
+


### PR DESCRIPTION
added missing folders to your manifest for the Pypi build (including pip install from locally cloned repo/git clone)

This should solve issue #22