### PR TITLE
Fix for #32

### DIFF
--- a/netbox_secretstore/template_content.py
+++ b/netbox_secretstore/template_content.py
@@ -12,11 +12,11 @@ class Secrets(PluginTemplateExtension):
 
 
 class DeviceSecrets(Secrets):
-    model = 'dcim.Device'
+    model = 'dcim.device'
 
 
 class VMSecrets(Secrets):
-    model = 'virtualization.VirtualMachine'
+    model = 'virtualization.virtualMachine'
 
 
 template_extensions = [DeviceSecrets, VMSecrets]


### PR DESCRIPTION
The card is missing from device pages because the model name is mis-capitalized.