### PR TITLE
Fixes: #91 Force using FormParser for GetSessionKeyViewSet

### DIFF
--- a/netbox_secretstore/api/views.py
+++ b/netbox_secretstore/api/views.py
@@ -10,6 +10,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.routers import APIRootView
 from rest_framework.viewsets import ViewSet
+from rest_framework.parsers import FormParser
 
 from extras.api.views import CustomFieldViewSet
 from netbox.api.viewsets import ModelViewSet
@@ -143,6 +144,9 @@ class GetSessionKeyViewSet(ViewSet):
     key will be returned instead of a new one.
     """
     permission_classes = [IsAuthenticated]
+
+    # Override Netbox DEFAULT_PARSER_CLASSES
+    parser_classes = [FormParser]
 
     @swagger_auto_schema(
         manual_parameters=[

--- a/netbox_secretstore/api/views.py
+++ b/netbox_secretstore/api/views.py
@@ -10,7 +10,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.routers import APIRootView
 from rest_framework.viewsets import ViewSet
-from rest_framework.parsers import FormParser
+from rest_framework.parsers import JSONParser, FormParser
 
 from extras.api.views import CustomFieldViewSet
 from netbox.api.viewsets import ModelViewSet
@@ -146,7 +146,7 @@ class GetSessionKeyViewSet(ViewSet):
     permission_classes = [IsAuthenticated]
 
     # Override Netbox DEFAULT_PARSER_CLASSES
-    parser_classes = [FormParser]
+    parser_classes = [JSONParser, FormParser]
 
     @swagger_auto_schema(
         manual_parameters=[


### PR DESCRIPTION
Netbox started enforcing application/json for API request in https://github.com/netbox-community/netbox/commit/bfbf97aec9119539f7f42cf16f52d0ca8203ba60

Which broke get-session-key. Override this.