### PR TITLE
Fix runtime issue with NetBox 3.3.10

### DIFF
--- a/netbox_secretstore/__init__.py
+++ b/netbox_secretstore/__init__.py
@@ -18,7 +18,7 @@ class NetBoxSecretStore(PluginConfig):
     author_email = metadata.get('Author-email')
     base_url = 'netbox_secretstore'
     min_version = '3.3.0beta1'
-    max_version = '3.3.9'
+    max_version = '3.3.10'
     required_settings = []
     default_settings = {
         'public_key_size': 2048


### PR DESCRIPTION
The plugin has a version check that limits the maximum version of NetBox to 3.3.9. Adjust this check to allow version 3.3.10 as well.

For newer release, e.g. NetBox 3.4.x this check needs to be adjusted accordingly.

This should fix #105.